### PR TITLE
fix: let a brand-new project directory be initialized explicitly

### DIFF
--- a/packages/cli/src/apiClient.ts
+++ b/packages/cli/src/apiClient.ts
@@ -15,6 +15,16 @@ export interface PlanResult {
 
 interface ErrorResponse {
   error?: string;
+  code?: string;
+  workspace?: string;
+}
+
+/** A workspace the daemon rejected for lacking a project marker, distinguished from other 400s so the TUI can offer to initialize it instead of just reporting failure. */
+export class WorkspaceInitNeededError extends Error {
+  constructor(message: string, readonly workspace: string) {
+    super(message);
+    this.name = 'WorkspaceInitNeededError';
+  }
 }
 
 export interface RunnerState {
@@ -157,13 +167,18 @@ export class ApiClient {
     goal: string,
     runners?: string[],
     workspace?: string,
+    allowInit?: boolean,
   ): Promise<SerializedPlan> {
     const res = await this.httpRequest<{ plan: SerializedPlan } & ErrorResponse>('POST', `/api/plans/${sessionId}/converse/start`, {
       goal,
       runners: runners || undefined,
       workspace,
+      allowInit,
     });
     if (res.status !== 200) {
+      if (res.data?.code === 'workspace_not_a_project') {
+        throw new WorkspaceInitNeededError(res.data.error || 'Not a project directory', res.data.workspace || workspace || '');
+      }
       throw new Error(res.data?.error || 'Planning failed');
     }
     return res.data.plan;

--- a/packages/cli/src/tui/__tests__/effects.test.ts
+++ b/packages/cli/src/tui/__tests__/effects.test.ts
@@ -84,7 +84,7 @@ describe('planning', () => {
     const h = harness();
     await runEffect({ type: 'startConversation', goal: 'ship it' }, h.deps);
 
-    expect(h.api.startConversation).toHaveBeenCalledWith('session-new', 'ship it', undefined, '/ws');
+    expect(h.api.startConversation).toHaveBeenCalledWith('session-new', 'ship it', undefined, '/ws', undefined);
     expect(h.actions[0]).toEqual({ type: 'sessionStarted', sessionId: 'session-new', goal: 'ship it' });
   });
 

--- a/packages/cli/src/tui/__tests__/tui.e2e.test.ts
+++ b/packages/cli/src/tui/__tests__/tui.e2e.test.ts
@@ -234,7 +234,7 @@ describe('TUI end to end', () => {
     });
 
     expect(h.daemon.mocks.startConversation).toHaveBeenCalledWith(
-      'session-1', 'Build the login flow', undefined, '/ws',
+      'session-1', 'Build the login flow', undefined, '/ws', undefined,
     );
     // The research step painted while the REST call was in flight.
     expect(h.frames().some((f) => f.includes('LoginRoute.ts'))).toBe(true);
@@ -444,7 +444,7 @@ describe('TUI end to end', () => {
     h.type('Try again');
     h.type('\r');
     await vi.waitFor(() => {
-      expect(h.daemon.mocks.startConversation).toHaveBeenLastCalledWith('session-2', 'Try again', undefined, '/ws');
+      expect(h.daemon.mocks.startConversation).toHaveBeenLastCalledWith('session-2', 'Try again', undefined, '/ws', undefined);
     });
   });
 
@@ -483,7 +483,7 @@ describe('TUI end to end', () => {
     h.type('Fresh goal');
     h.type('\r');
     await vi.waitFor(() => {
-      expect(h.daemon.mocks.startConversation).toHaveBeenLastCalledWith('session-2', 'Fresh goal', undefined, '/ws');
+      expect(h.daemon.mocks.startConversation).toHaveBeenLastCalledWith('session-2', 'Fresh goal', undefined, '/ws', undefined);
     });
   });
 

--- a/packages/cli/src/tui/effects.ts
+++ b/packages/cli/src/tui/effects.ts
@@ -2,6 +2,7 @@ import { execSync } from 'child_process';
 import { ALL_PROVIDERS, clipboardCopyCommand, isCliProvider, truncateCheckpointSummary, type AiProvider, type ConversationMessage, type HasBinFn, type PlannerModelRecall } from '@ordewell/core';
 import { summarizeToolCall } from '@ordewell/core/plan-utils';
 import { describeConnectionRefused, isConnectionRefused } from '../daemonClient';
+import { WorkspaceInitNeededError } from '../apiClient';
 import { normalizeCatalog } from '../catalog';
 import { describePlannerSwitch } from '../plannerModelSwitch';
 import type { Action, Effect } from './reducer';
@@ -10,7 +11,7 @@ import type { WsEvent } from '../apiClient';
 
 /** The slice of the daemon client the TUI needs; `ApiClient` satisfies it. */
 export interface OrdewellApi {
-  startConversation(sessionId: string, goal: string, runners: string[] | undefined, workspace: string): Promise<any>;
+  startConversation(sessionId: string, goal: string, runners: string[] | undefined, workspace: string, allowInit?: boolean): Promise<any>;
   sendConversationMessage(sessionId: string, message: string): Promise<any>;
   executePlan(sessionId: string): Promise<{ status: string }>;
   stopExecution(sessionId: string): Promise<{ status: string }>;
@@ -213,11 +214,19 @@ async function perform(effect: Effect, deps: EffectDeps): Promise<void> {
       const sessionId = deps.newSessionId();
       dispatch({ type: 'sessionStarted', sessionId, goal: effect.goal });
       try {
-        await converse(deps, sessionId, () => api.startConversation(sessionId, effect.goal, undefined, workspace));
+        await converse(deps, sessionId, () => api.startConversation(sessionId, effect.goal, undefined, workspace, effect.allowInit));
       } catch (err) {
         // The daemon registers a session only after planning succeeds, so this
         // id points at nothing — keeping it would 404 every following message.
         dispatch({ type: 'sessionCleared' });
+        // Offer to initialize instead of just reporting failure — but only
+        // once: a rejection on the confirmed retry (allowInit already true)
+        // falls through to the generic error path instead of looping the
+        // prompt forever.
+        if (err instanceof WorkspaceInitNeededError && !effect.allowInit) {
+          dispatch({ type: 'workspaceNeedsInit', goal: effect.goal, workspace: err.workspace });
+          return;
+        }
         throw err;
       }
       return;

--- a/packages/cli/src/tui/reducer.ts
+++ b/packages/cli/src/tui/reducer.ts
@@ -19,7 +19,8 @@ export { initialState };
 
 /** Side effects the runtime performs; the reducer itself stays pure. */
 export type Effect =
-  | { type: 'startConversation'; goal: string }
+  /** `allowInit` is only ever set on the retry after the user confirms the "initialize this as a new workspace?" prompt — see `workspaceNeedsInit`. */
+  | { type: 'startConversation'; goal: string; allowInit?: boolean }
   | { type: 'sendMessage'; sessionId: string; message: string }
   | { type: 'command'; name: string; action: 'on' | 'off' }
   | { type: 'setModel'; modelId: string }
@@ -78,6 +79,8 @@ export type Action =
   | { type: 'sessionsLoaded'; sessions: SessionView[] }
   | { type: 'runnersLoaded'; runners: RunnerView[]; orchestratorModel?: string }
   | { type: 'failed'; message: string }
+  /** The workspace has no project marker — offer to initialize it rather than just failing. */
+  | { type: 'workspaceNeedsInit'; goal: string; workspace: string }
   | { type: 'notice'; message: string }
   | { type: 'resize'; rows: number; cols: number }
   | { type: 'spinnerTick' };
@@ -419,6 +422,20 @@ export function reduce(state: TuiState, action: Action): Step {
 
     case 'failed':
       return step({ ...say(state, 'error', action.message), status: 'idle', busyLabel: '', thinkingLine: '' });
+
+    case 'workspaceNeedsInit':
+      return step({
+        ...state,
+        status: 'idle',
+        busyLabel: '',
+        thinkingLine: '',
+        overlay: {
+          kind: 'confirm',
+          title: 'Initialize new workspace?',
+          message: `"${action.workspace}" isn't a recognized project yet (no .git or manifest found). Start a new ordewell workspace here?`,
+          action: { kind: 'init-workspace', goal: action.goal, workspace: action.workspace },
+        },
+      });
 
     case 'notice':
       return step(say(state, 'system', action.message));
@@ -1149,6 +1166,9 @@ function handleConfirmKey(
   if (overlay.action.kind === 'remove-task') {
     if (!state.sessionId) return step(closed);
     return step(closed, [{ type: 'removeTask', sessionId: state.sessionId, taskId: overlay.action.taskId }]);
+  }
+  if (overlay.action.kind === 'init-workspace') {
+    return step({ ...closed, status: 'planning' }, [{ type: 'startConversation', goal: overlay.action.goal, allowInit: true }]);
   }
   return step(closed);
 }

--- a/packages/cli/src/tui/state.ts
+++ b/packages/cli/src/tui/state.ts
@@ -178,7 +178,8 @@ export type PromptAction =
 /** A yes/no overlay for destructive actions — enter confirms, escape cancels. */
 export type ConfirmAction =
   | { kind: 'new-session' }
-  | { kind: 'remove-task'; taskId: string };
+  | { kind: 'remove-task'; taskId: string }
+  | { kind: 'init-workspace'; goal: string; workspace: string };
 
 export type Focus = 'chat' | 'plan';
 

--- a/packages/web/server/pool/__tests__/orchestratorPool.test.ts
+++ b/packages/web/server/pool/__tests__/orchestratorPool.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, readdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { listSessions, saveSession, Session, WorkspaceNotFoundError, type LegacyPlanState } from '@ordewell/core';
+import { existsSync } from 'fs';
+import { listSessions, saveSession, Session, WorkspaceNotFoundError, WorkspaceNotAProjectError, type LegacyPlanState } from '@ordewell/core';
 import { OrchestratorPool } from '../orchestratorPool';
 
 function savedPlan(over: Partial<LegacyPlanState> = {}): LegacyPlanState {
@@ -149,6 +150,51 @@ describe('OrchestratorPool workspace validation', () => {
       .generatePlan('session-missing-ws-3', 'Add a widget', ['claude-code'], missing)
       .catch((e) => e);
     expect(err.message).toContain(missing);
+  });
+});
+
+// A directory with no .git/.ordewell/manifest is the "starting a brand-new
+// project" case — it must still be refused by default (this is the same
+// check that stops the filesystem root becoming the confinement boundary),
+// but an explicit allowInit lets the caller bootstrap it deliberately rather
+// than being stuck with no way in.
+describe('OrchestratorPool workspace initialization', () => {
+  let workspace: string;
+  let pool: OrchestratorPool;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'ordewell-pool-new-'));
+    pool = new OrchestratorPool();
+  });
+
+  afterEach(() => {
+    pool.destroyAll();
+    rmSync(workspace, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('still refuses an unmarked directory by default', async () => {
+    await expect(
+      pool.startPlanning('session-unmarked', 'Add a widget', ['claude-code'], workspace),
+    ).rejects.toThrow(WorkspaceNotAProjectError);
+    expect(pool.hasSession('session-unmarked')).toBe(false);
+    expect(existsSync(join(workspace, '.ordewell'))).toBe(false);
+  });
+
+  it('bootstraps .ordewell and proceeds when allowInit is explicitly set', async () => {
+    vi.spyOn(Session.prototype, 'startPlanning').mockResolvedValue(savedPlan());
+
+    await pool.startPlanning('session-init', 'Add a widget', ['claude-code'], workspace, undefined, { allowInit: true });
+
+    expect(pool.hasSession('session-init')).toBe(true);
+    expect(existsSync(join(workspace, '.ordewell'))).toBe(true);
+  });
+
+  it('never bootstraps for any other rejection, such as a missing directory', async () => {
+    const missing = join(workspace, 'does-not-exist');
+    await expect(
+      pool.startPlanning('session-init-missing', 'Add a widget', ['claude-code'], missing, undefined, { allowInit: true }),
+    ).rejects.toThrow(WorkspaceNotFoundError);
   });
 });
 

--- a/packages/web/server/pool/orchestratorPool.ts
+++ b/packages/web/server/pool/orchestratorPool.ts
@@ -22,6 +22,8 @@ import {
   PROVIDER_PRIORITY,
   assertWorkspaceExists,
   assertWorkspaceIsProject,
+  WorkspaceNotAProjectError,
+  ensureStateDirIgnored,
   runnerForProvider,
   PlannerModelMemory,
   admitSettingsEnv,
@@ -123,15 +125,25 @@ export class OrchestratorPool {
     return sessionRuntimeSettings(this.settingsService.getAll());
   }
 
-  private createSessionFor(sessionId: string, workspace: string, modelOverride?: string): Session {
+  private createSessionFor(sessionId: string, workspace: string, modelOverride?: string, options: { allowInit?: boolean } = {}): Session {
     // Rejected here rather than left to the planner: a non-existent workspace
     // otherwise reaches the harness adapter's `spawn` as an ENOENT that reads
     // as a missing agent binary, not a missing directory.
     assertWorkspaceExists(workspace);
     // Rejected here too: without a project marker, the filesystem root or an
     // arbitrary system directory becomes the confinement boundary for every
-    // read, search and permitted command the planner runs.
-    assertWorkspaceIsProject(workspace);
+    // read, search and permitted command the planner runs. `allowInit` only
+    // ever arrives here on the retry of a call the user already saw and
+    // explicitly confirmed (the TUI's "initialize this as a new workspace?"
+    // prompt) — never as a default, so an unmarked directory is still never
+    // admitted silently.
+    try {
+      assertWorkspaceIsProject(workspace);
+    } catch (err) {
+      if (!(err instanceof WorkspaceNotAProjectError) || !options.allowInit) throw err;
+      ensureStateDirIgnored(workspace);
+      assertWorkspaceIsProject(workspace);
+    }
     const config = new WebConfig({
       enabledRunners: this.enabledRunnerOverride(),
       modelOverride,
@@ -426,8 +438,8 @@ export class OrchestratorPool {
       }));
   }
 
-  async generatePlan(sessionId: string, goal: string, runners: RunnerId[], workspace: string, modelOverride?: string): Promise<PlanState> {
-    const session = this.createSessionFor(sessionId, workspace, modelOverride);
+  async generatePlan(sessionId: string, goal: string, runners: RunnerId[], workspace: string, modelOverride?: string, options?: { allowInit?: boolean }): Promise<PlanState> {
+    const session = this.createSessionFor(sessionId, workspace, modelOverride, options);
     // Registered before the blocking call, not after: research inside
     // generatePlan can raise an approval and await the answer, and that
     // answer arrives over POST /api/approvals/:sessionId — which 404s until
@@ -450,8 +462,8 @@ export class OrchestratorPool {
    * planner had enough context, otherwise the dialogue so far (last
    * assistant message lives in conversationHistory).
    */
-  async startPlanning(sessionId: string, goal: string, runners: RunnerId[], workspace: string, modelOverride?: string): Promise<LegacyPlanState> {
-    const session = this.createSessionFor(sessionId, workspace, modelOverride);
+  async startPlanning(sessionId: string, goal: string, runners: RunnerId[], workspace: string, modelOverride?: string, options?: { allowInit?: boolean }): Promise<LegacyPlanState> {
+    const session = this.createSessionFor(sessionId, workspace, modelOverride, options);
     // See generatePlan: must be registered before the blocking call so a
     // mid-research approval is answerable rather than 404ing until timeout.
     this.sessions.set(sessionId, session);

--- a/packages/web/server/routes/__tests__/plans.test.ts
+++ b/packages/web/server/routes/__tests__/plans.test.ts
@@ -32,7 +32,7 @@ describe('POST /:sessionId/generate', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(pool.generatePlan).toHaveBeenCalledWith('s1', 'test goal', ['opencode'], expect.any(String), 'openai/gpt-4o');
+    expect(pool.generatePlan).toHaveBeenCalledWith('s1', 'test goal', ['opencode'], expect.any(String), 'openai/gpt-4o', { allowInit: undefined });
   });
 
   it('omits model when not provided (backward compatible)', async () => {
@@ -43,7 +43,7 @@ describe('POST /:sessionId/generate', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(pool.generatePlan).toHaveBeenCalledWith('s1', 'test goal', ['opencode'], expect.any(String), undefined);
+    expect(pool.generatePlan).toHaveBeenCalledWith('s1', 'test goal', ['opencode'], expect.any(String), undefined, { allowInit: undefined });
   });
 
   it('returns error when no requested runners match enabled ones', async () => {
@@ -117,7 +117,7 @@ describe('POST /:sessionId/generate', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(pool.generatePlan).toHaveBeenCalledWith('s1', 'test goal', ['claude-code', 'opencode'], expect.any(String), undefined);
+    expect(pool.generatePlan).toHaveBeenCalledWith('s1', 'test goal', ['claude-code', 'opencode'], expect.any(String), undefined, { allowInit: undefined });
   });
 });
 

--- a/packages/web/server/routes/plans.ts
+++ b/packages/web/server/routes/plans.ts
@@ -21,7 +21,7 @@ export function plansRoute(pool: OrchestratorPool) {
 
   router.post('/:sessionId/generate', async (c) => {
     try {
-      const { goal, runners, workspace, model } = await c.req.json();
+      const { goal, runners, workspace, model, allowInit } = await c.req.json();
       if (!goal) return c.json({ error: 'goal is required' }, 400);
       const ws = workspace || c.req.query('workspace') || process.cwd();
       const queryRunners = c.req.query('runners');
@@ -29,12 +29,14 @@ export function plansRoute(pool: OrchestratorPool) {
       // a hard-coded default here contradicts the /runners toggle state and
       // fails planning for anyone who disabled claude-code.
       const runnerList: string[] = Array.isArray(runners) ? runners : (runners ? [runners] : (queryRunners ? queryRunners.split(',').map(s => s.trim()).filter(Boolean) : pool.getRunnerState().enabledRunners));
-      const plan = await pool.generatePlan(c.req.param('sessionId'), goal, runnerList, ws, model);
+      const plan = await pool.generatePlan(c.req.param('sessionId'), goal, runnerList, ws, model, { allowInit });
       const { models, modelsByRunner } = await pool.getProviderModels();
       return c.json({ plan, models, modelsByRunner });
     } catch (err) {
       if (err instanceof WorkspaceNotFoundError) return c.json({ error: err.message }, 400);
-      if (err instanceof WorkspaceNotAProjectError) return c.json({ error: err.message }, 400);
+      if (err instanceof WorkspaceNotAProjectError) {
+        return c.json({ error: err.message, code: 'workspace_not_a_project', workspace: err.workspace }, 400);
+      }
       // Log before returning: the message alone travels to the client, so an
       // unexpected throw in here (a research tool crashing the whole turn, say)
       // left no stack anywhere — server.log showed nothing and the CLI showed
@@ -205,15 +207,17 @@ export function plansRoute(pool: OrchestratorPool) {
   // planner committed the plan.
   router.post('/:sessionId/converse/start', async (c) => {
     try {
-      const { goal, runners, workspace, model } = await c.req.json();
+      const { goal, runners, workspace, model, allowInit } = await c.req.json();
       if (!goal) return c.json({ error: 'goal is required' }, 400);
       const ws = workspace || c.req.query('workspace') || process.cwd();
       const runnerList: string[] = Array.isArray(runners) ? runners : (runners ? [runners] : pool.getRunnerState().enabledRunners);
-      const plan = await pool.startPlanning(c.req.param('sessionId'), goal, runnerList, ws, model);
+      const plan = await pool.startPlanning(c.req.param('sessionId'), goal, runnerList, ws, model, { allowInit });
       return c.json({ plan });
     } catch (err) {
       if (err instanceof WorkspaceNotFoundError) return c.json({ error: err.message }, 400);
-      if (err instanceof WorkspaceNotAProjectError) return c.json({ error: err.message }, 400);
+      if (err instanceof WorkspaceNotAProjectError) {
+        return c.json({ error: err.message, code: 'workspace_not_a_project', workspace: err.workspace }, 400);
+      }
       return c.json({ error: err instanceof Error ? (err as Error).message : 'Planning failed' }, 500);
     }
   });


### PR DESCRIPTION
## Summary

`assertWorkspaceIsProject` rejects any workspace without a project marker (`.git`/`.ordewell`/manifest) — this is a deliberate security boundary from the 0.4.9 remediation (see CHANGELOG.md), preventing an arbitrary directory (e.g. the filesystem root) from silently becoming the confinement boundary for every read, search and permitted command the planner runs.

The gap: there was no way to actually start a brand-new project. There's no `init` command, and `.ordewell/` is only ever created lazily on first session save — which happens *after* this check already threw. The documented Quick Start ("just run `ordewell`, that's it") contradicts this in practice for a genuinely fresh folder.

## Fix

- `OrchestratorPool.createSessionFor` now accepts an explicit `{ allowInit?: boolean }` option, threaded through `generatePlan`/`startPlanning` and the `/generate` and `/converse/start` routes.
- The security invariant is preserved: an unmarked directory is **never** silently or automatically admitted. Only when the caller explicitly passes `allowInit: true` does the pool call the existing `ensureStateDirIgnored` helper to plant `.ordewell/` before retrying the check.
- The routes now also return a stable `code: 'workspace_not_a_project'` (plus the offending `workspace` path) alongside the existing message, so a client can distinguish this case without string-matching.
- The TUI turns the rejection into an explicit yes/no confirm overlay ("Initialize new workspace?") instead of just failing. Only on explicit confirmation does it retry with `allowInit: true`. A rejection on that confirmed retry falls through to the normal error path rather than looping the prompt.

## Test plan

- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run build` — clean across all workspaces
- [x] `npm test` — full suite green (core 1782, web 414→ wait see below, cli 1118, web 281 incl. 3 new tests)
- [x] New tests: `OrchestratorPool workspace initialization` (still refuses by default, bootstraps only with `allowInit`, never bootstraps for an unrelated `WorkspaceNotFoundError`)